### PR TITLE
implement VarStatement and AssignExpression

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -73,6 +73,31 @@ func (ls *LetStatement) String() string {
 }
 
 //====================================
+// AssignExpression
+//====================================
+type AssignExpression struct {
+	Token token.Token
+	Name  *Identifier
+	Value Expression
+}
+
+func (as *AssignExpression) expressionNode() {}
+func (as *AssignExpression) TokenLiteral() string {
+	return as.Token.Literal
+}
+func (as *AssignExpression) String() string {
+	var out bytes.Buffer
+
+	out.WriteString("(")
+	out.WriteString(as.Name.String())
+	out.WriteString(" = ")
+	out.WriteString(as.Value.String())
+	out.WriteString(")")
+
+	return out.String()
+}
+
+//====================================
 // ReturnStatement
 //====================================
 type ReturnStatement struct {

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -73,6 +73,34 @@ func (ls *LetStatement) String() string {
 }
 
 //====================================
+// VarStatement
+//====================================
+type VarStatement struct {
+	Token token.Token
+	Name  *Identifier
+	Value Expression
+}
+
+func (vs *VarStatement) statementNode() {}
+func (vs *VarStatement) TokenLiteral() string {
+	return vs.Token.Literal
+}
+func (vs *VarStatement) String() string {
+	var out bytes.Buffer
+
+	out.WriteString(vs.TokenLiteral() + " ")
+	out.WriteString(vs.Name.String())
+	out.WriteString(" = ")
+
+	if vs.Value != nil {
+		out.WriteString(vs.Value.String())
+	}
+	out.WriteString(";")
+
+	return out.String()
+}
+
+//====================================
 // AssignExpression
 //====================================
 type AssignExpression struct {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -97,6 +97,17 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 			return index
 		}
 		return evalIndexExpression(left, index)
+	case *ast.AssignExpression:
+		ident := evalIdentifier(node.Name, env)
+		if isError(ident) {
+			return ident
+		}
+		val := Eval(node.Value, env)
+		if isError(val) {
+			return val
+		}
+		env.Set(node.Name.Value, val)
+		return val
 	}
 
 	return nil
@@ -389,3 +400,4 @@ func evalHashLiteral(node *ast.HashLiteral, env *object.Environment) object.Obje
 	return &object.Hash{Pairs: pairs}
 
 }
+

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -519,3 +519,47 @@ func TestHashIndexExpressions(t *testing.T) {
 	}
 
 }
+
+func TestAssignExpressions(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{
+			`let x = 5; x = x + 1; x;`,
+			6,
+		},
+		{
+			`let x = 5; x = x + 1; x = x + 1; x;`,
+			7,
+		},
+		{
+			`let x = "hoge"; x = x + "fuga";`,
+			"hogefuga",
+		},
+		{
+			`let x = 5; let y = x = 7; y;`,
+			7,
+		},
+		{
+			`let x = 1; let y = 2; let z = x = y = 3; z;`,
+			3,
+		},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		switch expected := tt.expected.(type) {
+		case int:
+			testIntegerObject(t, evaluated, int64(expected))
+		case string:
+			ret , ok := evaluated.(*object.String)
+			if !ok {
+				t.Fatalf("object is not String. got=%T (%+v)", evaluated, evaluated)
+			}
+			if ret.Value != expected {
+				t.Errorf("ret is %q, want=%q", ret.Value, expected)
+			}
+		}
+	}
+}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -526,23 +526,23 @@ func TestAssignExpressions(t *testing.T) {
 		expected interface{}
 	}{
 		{
-			`let x = 5; x = x + 1; x;`,
+			`var x = 5; x = x + 1; x;`,
 			6,
 		},
 		{
-			`let x = 5; x = x + 1; x = x + 1; x;`,
+			`var x = 5; x = x + 1; x = x + 1; x;`,
 			7,
 		},
 		{
-			`let x = "hoge"; x = x + "fuga";`,
+			`var x = "hoge"; x = x + "fuga";`,
 			"hogefuga",
 		},
 		{
-			`let x = 5; let y = x = 7; y;`,
+			`var x = 5; var y = x = 7; y;`,
 			7,
 		},
 		{
-			`let x = 1; let y = 2; let z = x = y = 3; z;`,
+			`var x = 1; var y = 2; var z = x = y = 3; z;`,
 			3,
 		},
 	}

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -9,6 +9,7 @@ func TestNextToken(t *testing.T) {
 	input := `
 let five = 5;
 let ten = 10;
+var hoge = 1;
 
 let add = fn(x, y) {
 	x + y;
@@ -49,6 +50,13 @@ if (5 < 10) {
 		{token.IDENT, "ten"},
 		{token.ASSIGN, "="},
 		{token.INT, "10"},
+		{token.SEMICOLON, ";"},
+
+		// let hoge = 1;
+		{token.VAR, "var"},
+		{token.IDENT, "hoge"},
+		{token.ASSIGN, "="},
+		{token.INT, "1"},
 		{token.SEMICOLON, ";"},
 
 		// let add = fn(x, y) { x + y; };

--- a/object/environment.go
+++ b/object/environment.go
@@ -1,12 +1,17 @@
 package object
 
+type Value struct {
+	Obj Object
+	IsMutable bool
+}
+
 type Environment struct {
-	store map[string]Object
+	store map[string]*Value
 	outer *Environment
 }
 
 func NewEnvironment() *Environment {
-	s := make(map[string]Object)
+	s := make(map[string]*Value)
 	return &Environment{store: s, outer: nil}
 }
 
@@ -16,15 +21,16 @@ func NewEnclosedEnvironment(outer *Environment) *Environment {
 	return env
 }
 
-func (e *Environment) Get(name string) (Object, bool) {
-	obj, ok := e.store[name]
+func (e *Environment) Get(name string) (*Value, bool) {
+	val, ok := e.store[name]
 	if !ok && e.outer != nil {
-		obj, ok = e.outer.Get(name)
+		val, ok = e.outer.Get(name)
 	}
-	return obj, ok
+	return val, ok
 }
 
-func (e *Environment) Set(name string, val Object) Object {
-	e.store[name] = val
-	return val
+func (e *Environment) Set(name string, obj Object, isMutable bool) *Value {
+	val := Value{Obj:obj, IsMutable: isMutable}
+	e.store[name] = &val
+	return &val
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -113,6 +113,8 @@ func (p *Parser) parseStatement() ast.Statement {
 	switch p.curToken.Type {
 	case token.LET:
 		return p.parseLetStatement()
+	case token.VAR:
+		return p.parseVarStatement()
 	case token.RETURN:
 		return p.parseReturnStatement()
 	default:
@@ -122,6 +124,30 @@ func (p *Parser) parseStatement() ast.Statement {
 
 func (p *Parser) parseLetStatement() *ast.LetStatement {
 	stmt := &ast.LetStatement{Token: p.curToken}
+
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+
+	stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+
+	if !p.expectPeek(token.ASSIGN) {
+		return nil
+	}
+
+	p.nextToken()
+
+	stmt.Value = p.parseExpression(LOWEST)
+
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+	}
+
+	return stmt
+}
+
+func (p *Parser) parseVarStatement() *ast.VarStatement {
+	stmt := &ast.VarStatement{Token: p.curToken}
 
 	if !p.expectPeek(token.IDENT) {
 		return nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -65,6 +65,64 @@ func testLetStatement(t *testing.T, s ast.Statement, name string) bool {
 	return true
 }
 
+func TestVarStatements(t *testing.T) {
+	tests := []struct {
+		input              string
+		expectedIdentifier string
+		expectedValue      interface{}
+	}{
+		{"var x = 5", "x", 5},
+		{"var y = true", "y", true},
+		{"var foobar = y", "foobar", "y"},
+	}
+
+	for _, tt := range tests {
+		l := lexer.New(tt.input)
+		p := New(l)
+		program := p.ParseProgram()
+		checkParserErrors(t, p)
+
+		if len(program.Statements) != 1 {
+			t.Errorf("len(program.Statements) = %v, want %v", len(program.Statements), 1)
+		}
+
+		stmt := program.Statements[0]
+		if !testVarStatement(t, stmt, tt.expectedIdentifier) {
+			return
+		}
+
+		val := stmt.(*ast.VarStatement).Value
+		if !testLiteralExpression(t, val, tt.expectedValue) {
+			return
+		}
+	}
+}
+
+func testVarStatement(t *testing.T, s ast.Statement, name string) bool {
+	if s.TokenLiteral() != "var" {
+		t.Errorf("s.TokenLiteral = %v, want %v", s.TokenLiteral(), "var")
+		return false
+	}
+
+	varStmt, ok := s.(*ast.VarStatement)
+	if !ok {
+		t.Errorf("s isn't *ast.VarStatement. got=%T", s)
+		return false
+	}
+
+	if varStmt.Name.Value != name {
+		t.Errorf("varStmt.Name.Value = %v, want %v", varStmt.Name.Value, name)
+		return false
+	}
+
+	if varStmt.Name.TokenLiteral() != name {
+		t.Errorf("varStmt.Name.TokenLiteral = %v, want %v", varStmt.Name.TokenLiteral(), name)
+		return false
+	}
+
+	return true
+}
+
 func checkParserErrors(t *testing.T, p *Parser) {
 	errors := p.Errors()
 	if len(errors) == 0 {

--- a/token/token.go
+++ b/token/token.go
@@ -41,6 +41,7 @@ const (
 
 	FUNCTION = "FUNCTION"
 	LET      = "LET"
+	VAR      = "VAR"
 	TRUE     = "TRUE"
 	FALSE    = "FALSE"
 	IF       = "IF"
@@ -51,6 +52,7 @@ const (
 var keywords = map[string]TokenType{
 	"fn":     FUNCTION,
 	"let":    LET,
+	"var":    VAR,
 	"true":   TRUE,
 	"false":  FALSE,
 	"if":     IF,


### PR DESCRIPTION
VarStatement defines new identifier which can reassign value. 
AssignExpression assigns value to defined identifier and returns value. 
The example is as follows.
```
>> var i = 0; i = 1;
1
>> var x = 1; var y = 2; var z = x = y = 3;   
>> x
3
>> y
3
>> z
3
>> j = 0
ERROR: identifier not found: j
>> let k = 0
>> k = 1
ERROR: can't assign value to immutable identifier: k
```